### PR TITLE
Feature/华泰查询交割

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# cache
+tmp/

--- a/easytrader/config/ht.json
+++ b/easytrader/config/ht.json
@@ -72,5 +72,18 @@
     "identity_type": "",
     "entrust_bs": 2,
     "batch_flag": 0
+  },
+  "exchangebill":{
+    "cssweb_type": "GET_EXCHANGEBILL",
+    "request_num": 100,
+    "end_date": "",
+    "start_date": "",
+    "exchange_type": "",
+    "stock_code": "",
+    "deliver_type": 1,
+    "query_direction": "",
+    "function_id": 308,
+    "stock_account": "",
+    "position_str": ""
   }
 }

--- a/easytrader/helpers.py
+++ b/easytrader/helpers.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import uuid
 import six
+import datetime
 
 import logbook
 from logbook import Logger, StreamHandler
@@ -106,3 +107,15 @@ def get_logger(name):
     logbook.set_datetime_format('local')
     StreamHandler(sys.stdout).push_application()
     return Logger(os.path.basename(name))
+
+
+def get_30_date():
+    """
+    获得用于查询的默认日期, 今天的日期, 以及30天前的日期
+    用于查询的日期格式通常为 20160211
+    :return:
+    """
+    now = datetime.datetime.now()
+    end_date = now.date()
+    start_date = end_date - datetime.timedelta(days=30)
+    return start_date.strftime("%Y%m%d"), end_date.strftime("%Y%m%d")

--- a/easytrader/httrader.py
+++ b/easytrader/httrader.py
@@ -293,3 +293,24 @@ class HTTrader(WebTrader):
     def fix_error_data(self, data):
         last_no_use_info_index = -1
         return data if hasattr(data, 'get') else data[:last_no_use_info_index]
+
+
+    @property
+    def exchangebill(self):
+        start_date, end_date = helpers.get_30_date()
+        return self.get_exchangebill(start_date, end_date)
+
+
+    def get_exchangebill(self, start_date, end_date):
+        """
+        查询指定日期内的交割单
+        :param start_date: 20160211
+        :param end_date: 20160211
+        :return:
+        """
+        params = self.config['exchangebill'].copy()
+        params.update({
+            "start_date": start_date,
+            "end_date": end_date,
+        })
+        return self.do(params)

--- a/easytrader/webtrader.py
+++ b/easytrader/webtrader.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import time
+import datetime
 from threading import Thread
 
 import six
@@ -119,6 +120,28 @@ class WebTrader(object):
     def get_entrust(self):
         """获取当日委托列表"""
         return self.do(self.config['entrust'])
+
+    @property
+    def exchangebill(self):
+        """
+        默认提供最近30天的交割单, 通常只能返回查询日期内最新的 90 天数据。
+        :return:
+        """
+        # TODO 目前仅在 华泰子类 中实现
+        start_date, end_date = helpers.get_30_date()
+        return self.get_exchangebill(start_date, end_date)
+
+
+    def get_exchangebill(self, start_date, end_date):
+        """
+        查询指定日期内的交割单
+        :param start_date: 20160211
+        :param end_date: 20160211
+        :return:
+        """
+        # TODO 目前仅在 华泰子类 中实现
+        log.info('目前仅在 华泰子类 中实现, 其余券商需要补充')
+
 
     def do(self, params):
         """发起对 api 的请求并过滤返回结果

--- a/test_easytrader.py
+++ b/test_easytrader.py
@@ -97,6 +97,11 @@ class TestEasytrader(unittest.TestCase):
         result = helpers.str2num(test_data, 'float')
         self.assertAlmostEqual(result, normal_data)
 
+    def test_ht_format_exchagnebill_request_data(self):
+        user = easytrader.use('ht')
+        import datetime
+        # print(datetime.datetime.now().strftime("%Y%m%d"))
+        # user.exchangebill
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
在华泰模块下实现了查询交割单的接口，没有在父类中实现，因为不知道是否所有的券商查询交割的格式都一样，主要是查询的始末日期的 key  start_date 和 end_date。如果都一样的话，可以考虑直接在父类中中实现。