### PR TITLE
yhtrader

### DIFF
--- a/easytrader/helpers.py
+++ b/easytrader/helpers.py
@@ -164,12 +164,23 @@ def detect_gf_result(image_path):
 def detect_yh_result(image_path):
     from PIL import Image
     import pytesseract
+    import numpy
+
     img = Image.open(image_path)
+
+    brightness = list()
     for x in range(img.width):
         for y in range(img.height):
             (r, g, b) = img.getpixel((x, y))
-            if r > 100 and g > 100 and b > 100:
+            brightness.append( r+g+b )
+    avgBrightness = int( numpy.mean(brightness) )
+
+    for x in range(img.width):
+        for y in range(img.height):
+            (r, g, b) = img.getpixel((x, y))
+            if  ( (r+g+b)>avgBrightness/1.5 ) or (y<3) or (y>17) or (x<5) or ( x>(img.width-5) ):
                 img.putpixel((x, y), (256, 256, 256))
+    
     res = pytesseract.image_to_string(img)
     return res
 

--- a/easytrader/yhtrader.py
+++ b/easytrader/yhtrader.py
@@ -147,7 +147,7 @@ class YHTrader(WebTrader):
         )
         return self.__trade(stock_code, price, entrust_prop=entrust_prop, other=params)
 
-    def sell(self, stock_code, price, amount=0, volume=0, entrust_prop=0):
+    def sell(self, stock_code, price, amount=0, volume=0, entrust_prop=EntrustProp.Limit):
         """卖出股票
         :param stock_code: 股票代码
         :param price: 卖出价格

--- a/easytrader/yhtrader.py
+++ b/easytrader/yhtrader.py
@@ -6,7 +6,6 @@ import random
 import re
 
 import requests
-import pandas
 
 from . import helpers
 from .helpers import EntrustProp
@@ -112,7 +111,7 @@ class YHTrader(WebTrader):
         self.cookie = dict(JSESSIONID=token)
         self.keepalive()
 
-    def check_available_cancels(self, parsed = True, df = False):
+    def check_available_cancels(self, parsed = True):
         """
         @Contact: Emptyset <21324784@qq.com>
         检查撤单列表
@@ -145,9 +144,6 @@ class YHTrader(WebTrader):
                 ,   "account":      item[11]
                 }
                 result.append(item_dict)
-            if df == True:
-                cancel_df = pandas.DataFrame.from_records( result )
-                return cancel_df
         return result
 
     def cancel_entrust(self, entrust_no, stock_code):

--- a/easytrader/yhtrader.py
+++ b/easytrader/yhtrader.py
@@ -6,6 +6,7 @@ import random
 import re
 
 import requests
+import pandas
 
 from . import helpers
 from .helpers import EntrustProp
@@ -17,6 +18,15 @@ VERIFY_CODE_POS = 0
 TRADE_MARKET = 1
 HOLDER_NAME = 0
 
+# 用于将一个list按一定步长切片，返回这个list切分后的list
+def slice_list(step = None, num = None, data_list=None):
+    if not ( (step is None) & (num is None) ):
+        if num is not None:
+            step = math.ceil(len(data_list)/num)
+        return [data_list[ i : i + step] for i in range(0, len(data_list), step)]
+    else:
+        print("step和num不能同时为空")
+        return False
 
 class YHTrader(WebTrader):
     config_path = os.path.dirname(__file__) + '/config/yh.json'
@@ -102,6 +112,44 @@ class YHTrader(WebTrader):
         self.cookie = dict(JSESSIONID=token)
         self.keepalive()
 
+    def check_available_cancels(self, parsed = True, df = False):
+        """
+        @Contact: Emptyset <21324784@qq.com>
+        检查撤单列表
+        """
+        try:
+            response = self.s.get( "https://www.chinastock.com.cn/trade/webtrade/stock/StockEntrustCancel.jsp", cookies=self.cookie )
+            html = response.text.replace("\t","").replace("\n","").replace("\r","")
+            pattern = r'<tr\s(?:[a-zA-Z0-9\:\=\'\"\(\)\s]*)>(.+)</tr></TBODY>'
+            result1 = re.findall(pattern, html)[0]
+            pattern = r'<td\s(?:[a-zA-Z0-9=_\"\:]*)>([\S]+)</td>'
+            parsed_data = re.findall(pattern, result1)
+            cancel_list = slice_list(step = 12, data_list = parsed_data)
+        except Exception as e:
+            return []
+        if parsed == True:
+            result = list()
+            for item in cancel_list:
+                item_dict = {
+                    "time"  :   item[0]
+                ,   "code"  :   item[1]
+                ,   "name"  :   item[2]
+                ,   "status":   item[3]
+                ,   "iotype":   item[4]
+                ,   "price" :   float(item[5])
+                ,   "volume":   int(item[6])
+                ,   "entrust_num": item[7]
+                ,   "trans_vol": int(item[8])
+                ,   "canceled_vol": int(item[9])
+                ,   "investor_code": item[10]
+                ,   "account":      item[11]
+                }
+                result.append(item_dict)
+            if df == True:
+                cancel_df = pandas.DataFrame.from_records( result )
+                return cancel_df
+        return result
+
     def cancel_entrust(self, entrust_no, stock_code):
         """撤单
         :param entrust_no: 委托单号
@@ -114,14 +162,46 @@ class YHTrader(WebTrader):
         )
         cancel_response = self.s.post(self.config['trade_api'], params=cancel_params)
         log.debug('cancel trust: %s' % cancel_response.text)
-        return True
+        return cancel_response.json()
+
+    def cancel_entrusts(self, entrust_no):
+        """
+        @Contact: Emptyset <21324784@qq.com>
+        批量撤单
+        @param
+            entrust_no: string类型
+                        委托单号，用逗号隔开
+                        e.g:"8000,8001,8002"
+        """
+        list_entrust_no = entrust_no.split(",")
+        if list_entrust_no[-1] is "":
+            num = len(list_entrust_no) - 1
+        else:
+            num = len(list_entrust_no)
+        cancel_data = {
+            "ajaxFlag":"stock_batch_cancel"
+        ,   "num":num
+        ,   "orderSno": entrust_no
+        }
+        while True:
+            try:
+                cancel_response = self.s.post(
+                    "https://www.chinastock.com.cn/trade/AjaxServlet"
+                ,   data = cancel_data
+                )
+                break
+            except Exception as e:
+                log.debug( '{}'.format(e) )
+        return cancel_response.json()
 
     @property
     def current_deal(self):
         return self.get_current_deal()
 
     def get_current_deal(self):
-        """获取当日成交列表."""
+        """
+        获取当日成交列表.
+        """
         return self.do(self.config['current_deal'])
 
     def buy(self, stock_code, price, amount=0, volume=0, entrust_prop=EntrustProp.Limit):
@@ -261,6 +341,8 @@ class YHTrader(WebTrader):
                 secuid=need_info['stock_account']
         )
         trade_response = self.s.post(self.config['trade_api'], params=trade_params)
+        log.debug( "{}".format( self.config['trade_api'] ) )
+        log.debug( "{}".format( trade_params ) )
         log.debug('trade response: %s' % trade_response.text)
         return trade_response.json()
 
@@ -285,6 +367,8 @@ class YHTrader(WebTrader):
         url = self.trade_prefix + params['service_jsp']
         r = self.s.get(url, cookies=self.cookie)
         if params['service_jsp'] == '/trade/webtrade/stock/stock_zjgf_query.jsp':
+            if r.text.find('系统超时请重新登录') != -1:
+                return False
             if params['service_type'] == 2:
                 rptext = r.text[0:r.text.find('操作')]
                 return rptext
@@ -296,6 +380,8 @@ class YHTrader(WebTrader):
             return r.text
 
     def format_response_data(self, data):
+        if data == False:
+            return False
         # 需要对于银河持仓情况特殊处理
         if data.find('yhposition') != -1:
             search_result_name = re.findall(r'<td nowrap=\"nowrap\" class=\"head(?:\w{0,5})\">(.*)</td>', data)
@@ -308,7 +394,7 @@ class YHTrader(WebTrader):
                     s = k[-1]
                 search_result_content.append(s)
         else:
-            # 获取原始data的html源码并且解析得到一个可读json格式 
+            # 获取原始data的html源码并且解析得到一个可读json格式
             search_result_name = re.findall(r'<td nowrap=\"nowrap\" class=\"head(?:\w{0,5})\">(.*)</td>', data)
             search_result_content = re.findall(r'<td nowrap=\"nowrap\">(.*)&nbsp;</td>', data)
 
@@ -337,7 +423,8 @@ class YHTrader(WebTrader):
         heartbeat_params = dict(
                 ftype='bsn'
         )
-        self.s.post(self.config['heart_beat'], params=heartbeat_params)
+        res = self.s.post(self.config['heart_beat'], params=heartbeat_params)
+        # log.debug( "Heart Beat Response: {}".format(res.text) )
 
     def unlockscreen(self):
         unlock_params = dict(


### PR DESCRIPTION
1. 增加了cancel_entrusts接口，用于批量撤单，返回dict类型
2. 增加check_available_cancels接口，用于检查可撤单列表
3. 修改了cancel_entrust的返回数据，将原无脑返回True改为返回response具体内容
4. 给检查持仓接口get_position增加了掉线判断（原先掉线时会返回空list，现在会返回False）