### PR TITLE
修正exchange_type异常问题

### DIFF
--- a/easytrader/gftrader.py
+++ b/easytrader/gftrader.py
@@ -138,13 +138,12 @@ class GFTrader(WebTrader):
         jsholder = jslist[HOLDER_POS]
         jsholder = re.findall(r'\[(.*)\]', jsholder)
         jsholder = eval(jsholder[0])
-
-        if len(jsholder) < 3:
-            self.holdername.append(jsholder[0])
-            self.holdername.append(jsholder[1])
-            return
-        self.holdername.append(jsholder[1])
-        self.holdername.append(jsholder[2])
+        for jsholder_sh in  jsholder:
+            if jsholder_sh['exchange_name']=='上海':
+                self.holdername.append(jsholder_sh)
+        for jsholder_sz in  jsholder:
+            if jsholder_sz['exchange_name']=='深圳':
+                self.holdername.append(jsholder_sz)
 
     def __get_trade_need_info(self, stock_code):
         """获取股票对应的证券市场和帐号"""


### PR DESCRIPTION
故障现象：
（1）在执行委托的时候，报错。提示： {"error_no":"-51","total":0,"error_info":"[101015][证券代码表记录不存在]\r\n[exchange_type\u003dG,stock_code\u003d002185]\n","success":false}
（2）查看委托参数， {'entrust_prop': 0, 'entrust_bs': 1, 'stock_account': 'A258825546', 'exchange_type': 'G', 'stock_code': '002185', 'entrust_price': '13', 'entrust_amount': '1000.0', 'method': 'entrust', 'classname': 'com.gf.etrade.control.StockUF2Control', 'dse_sessionId': 'B1CDA0A3E155006BF01CA69FFBAC11BC'}
   出现exchange_type为G这种特殊情况。

问题原因：当jsholder有超过2个的时候，原先方案只是靠位置定位相关信息，存在一定不准确性。修正后方案，根据实际数据在添加到holdername中。
测试情况：
目前测试了两个账号：一种是jsholder只有2个，一种jsholder有3个，都成功执行委托。