### PR TITLE
修复HTTrader在python3.5环境下判断账号是否存在的bug

### DIFF
--- a/easytrader/httrader.py
+++ b/easytrader/httrader.py
@@ -31,6 +31,10 @@ class HTTrader(WebTrader):
 
         self.__set_ip_and_mac()
         self.fund_account = None
+        
+        # 账户初始化为None
+        self.__sh_stock_account = None
+        self.__sz_stock_account = None
 
     def __set_ip_and_mac(self):
         """获取本机IP和MAC地址"""
@@ -226,14 +230,14 @@ class HTTrader(WebTrader):
         """获取股票对应的证券市场和帐号"""
         #判断股票类型和是否存在对应证券账号
         if helpers.get_stock_type(stock_code) == 'sh':
-            if hasattr(self,'__sh_stock_account') == False:
-                raise Exception("没有上证账户，不可买入上证股票。")
+            if self.__sh_stock_account is None:
+                raise Exception("没有上证账户，不可买入、卖出上证股票。")
             else:
                 exchange_type = self.__sh_exchange_type
                 stock_account = self.__sh_stock_account
         else:
-            if hasattr(self,'__sz_stock_account') == False:
-                raise Exception("没有深证账户，不可买入深证股票。")
+            if self.__sz_stock_account is None:
+                raise Exception("没有深证账户，不可买入、卖出深证股票。")
             else:
                 exchange_type = self.__sz_exchange_type
                 stock_account = self.__sz_stock_account


### PR DESCRIPTION
python3.5继承的时候会自动在私有属性前面加上_类名，比如_HTTrader，所以hasattr就出错了