### PR TITLE
修复follow聚宽交易下单失败的问题

### DIFF
--- a/easytrader/helpers.py
+++ b/easytrader/helpers.py
@@ -48,7 +48,8 @@ def get_stock_type(stock_code):
     ['5', '6', '9'] 开头的为 sh， 其余为 sz
     :param stock_code:股票ID, 若以 'sz', 'sh' 开头直接返回对应类型，否则使用内置规则判断
     :return 'sh' or 'sz'"""
-    assert type(stock_code) is str, 'stock code need str type'
+    if type(stock_code) is not str and type(stock_code) is not unicode:
+        raise Exception('stock code not string. curr type is: {}'.format(type(stock_code)))
     if stock_code.startswith(('sh', 'sz')):
         return stock_code[:2]
     if stock_code.startswith(('50', '51', '60', '73', '90', '110', '113', '132', '204', '78')):

--- a/test_easytrader.py
+++ b/test_easytrader.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import unittest
 from datetime import datetime
 


### PR DESCRIPTION
follow聚宽的交易时，由于resp.json()返回stock code类型是unicode，helper中的判断会导致assert error，导致无法下单