### PR TITLE
修复get_entrust为返回所有委托信息

### DIFF
--- a/easytrader/config/gf.json
+++ b/easytrader/config/gf.json
@@ -30,6 +30,13 @@
     "start": 0,
     "limit": 10
   },
+  "entrust_pos":{
+  "classname": "com.gf.etrade.control.StockUF2Control",
+  "method": "queryDRWT",
+  "request_num": 100,
+  "query_direction": 0,
+  "query_mode": 0
+  },
   "cancel_entrust": {
     "classname": "com.gf.etrade.control.StockUF2Control",
     "method": "cancel",

--- a/easytrader/gftrader.py
+++ b/easytrader/gftrader.py
@@ -558,7 +558,7 @@ class GFTrader(WebTrader):
         log.debug(self.do(params))
         self.heart_active = False
 
-    def get_entrust(self, action_in=0):
+    def get_entrust_without_pos(self, action_in=0):
         '''
 
         :param action_in: 当值为0，返回全部委托；当值为1时，返回可撤委托
@@ -569,3 +569,50 @@ class GFTrader(WebTrader):
             "action_in": action_in,
         })
         return self.do(params)
+
+    def get_entrust(self, action_in):
+        '''
+
+        :param action_in: 当值为0，返回全部委托；当值为1时，返回可撤委托
+        :return: 字典形式的返回值
+        '''
+        data, total = self.get_value(action_in)
+        return {u'data': data, u'total': total, u'success': True}
+
+    def get_entrust_with_pos(self, postion_str):
+        '''
+
+        :param position_str: 用于标记查询委托单号的起点
+        :return: 字典形式的返回值
+        '''
+        params = self.config['entrust_pos'].copy()
+        params.update({
+            "postion_str": postion_str,
+        })
+        return self.do(params)
+
+    def get_value(self, action_in):
+        '''
+        1.委托数量在100单以下，直接返回值
+        2.查询委托的数量等于100单，调用带position_str参数的委托查询方法
+        3.直到最后一次的查询返回值小于100单，结束循环，构造返回值
+
+        :param action_in: 当值为0，返回全部委托；当值为1时，返回可撤委托
+        :return:（数据列表，数据总数）构成的元组
+        '''
+        data = []
+        total = 0
+
+        result = self.get_entrust_without_pos(action_in)
+
+        while True:
+            data += result[u'data']
+            total += result[u'total']
+
+            if result[u'total'] < 100:
+                break
+            result = self.get_entrust_with_pos(
+                action_in, result[u'data'][-1]['position_str']
+            )
+
+        return data, total

--- a/test_gftrader_get_entrust.py
+++ b/test_gftrader_get_entrust.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Author: heheqiao(614400597@qq.com)
+#
+'''Test for ``trader.FixedTrader``
+'''
+import mock
+from nose.tools import assert_equal
+from easytrader import gftrader
+
+
+@mock.patch.object(gftrader.GFTrader, 'get_value')
+def test_get_entrust(mock_get_value):
+    '''UnitTest of ``gftrader.GFTrader.get_entrust``
+    '''
+    mock_get_value.return_value = (
+        [u'test', u'test'], 100
+    )
+
+    assert_equal(
+        gftrader.GFTrader().get_entrust(0),
+        {u'data': [u'test', u'test'], u'total': 100, u'success': True}
+    )
+
+
+@mock.patch.object(gftrader.GFTrader, 'do')
+def test_get_entrust_with_pos(mock_do):
+    '''UnitTest of ``gftrader.GFTrader.get_entrust_with_pos``
+    '''
+    gftrader.GFTrader().get_entrust_with_pos(u'test')
+
+    mock_do.assert_called_with({
+        u'classname': u'com.gf.etrade.control.StockUF2Control',
+        u'query_mode': 0, u'query_direction': 0,
+        u'postion_str': u'test',
+        u'request_num': 100,
+        u'method': u'queryDRWT'
+    })
+
+
+@mock.patch.object(gftrader.GFTrader, 'get_entrust_without_pos')
+@mock.patch.object(gftrader.GFTrader, 'get_entrust_with_pos')
+def test_get_value(mock_get_pos, mock_get):
+    '''UnitTest of ``gftrader.GFTrader.get_value``
+    '''
+    # Case1:result[u'total'] < 100
+    mock_get.return_value = {
+        u'data': [u'test'], u'total': 1
+    }
+
+    assert_equal(
+        gftrader.GFTrader().get_value(0),
+        ([u'test'], 1)
+    )
+    mock_get_pos.assert_not_called()
+
+    # Case2:result[u'total'] >= 100
+    mock_get.return_value = {
+        u'data': [{u'position_str': u'test'}], u'total': 100
+    }
+    mock_get_pos.return_value = {
+        u'data': [u'test'], u'total': 50
+    }
+
+    assert_equal(
+        gftrader.GFTrader().get_value(0),
+        ([{u'position_str': u'test'}, u'test'], 150)
+    )
+    mock_get_pos.assert_called_with(0, u'test')


### PR DESCRIPTION
1.原有``get_entrust``方法更名为``get_entrust_without_pos``
2.添加``get_entrust_with_pos``方法：接收起点参数，进行委托查询
3.添加``get_value``进行``get_entrust_with_pos``与``get_entrust_without_pos``的调度，使得能够返回所有委托信息