### PR TITLE
修复pythoncom在多线程未初始化的Bug。

### DIFF
--- a/easytrader/yh_clienttrader.py
+++ b/easytrader/yh_clienttrader.py
@@ -302,6 +302,8 @@ class YHClientTrader():
 
     @staticmethod
     def _set_foreground_window(hwnd):
+        import pythoncom
+        pythoncom.CoInitialize()
         shell = win32com.client.Dispatch('WScript.Shell')
         shell.SendKeys('%')
         win32gui.SetForegroundWindow(hwnd)


### PR DESCRIPTION
由于win32实例无法在多线程共享，所以每个线程需要重新初始化。