### PR TITLE
clienttrader中登录配置支持exe_path和comm_password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ gft.json
 test.py
 ht_account.json
 .idea
+.vscode
 .ipynb_checkpoints
 Untitled.ipynb
 untitled.txt
@@ -11,6 +12,7 @@ untitled.txt
 __pycache__/
 *.py[cod]
 account.json
+account.session
 # C extensions
 *.so
 

--- a/cli.py
+++ b/cli.py
@@ -20,7 +20,7 @@ ACCOUNT_OBJECT_FILE = 'account.session'
 def main(prepare, use, do, get, params, debug):
     if get is not None:
         do = get
-    if prepare is not None and use in ['ht', 'yjb', 'yh', 'gf', 'xq']:
+    if prepare is not None and use in ['ht_client', 'yjb', 'yh_client','yh','ht', 'gf', 'xq']:
         user = easytrader.use(use, debug)
         user.prepare(prepare)
         with open(ACCOUNT_OBJECT_FILE, 'wb') as f:

--- a/easytrader/clienttrader.py
+++ b/easytrader/clienttrader.py
@@ -103,6 +103,8 @@ class ClientTrader:
             account = helpers.file2dict(config_path)
             user = account['user']
             password = account['password']
+            comm_password = account.get('comm_password')
+            exe_path = account.get('exe_path')
         self.login(user, password, exe_path or self._config.DEFAULT_EXE_PATH, comm_password, **kwargs)
 
     @abstractmethod


### PR DESCRIPTION
1. clienttrader中登录配置支持exe_path和comm_password
2. cli.py 中增加yh_client, ht_client 
3. gitignore 忽略.vscode、account.session