### PR TITLE
关于refresh、撤单PopDialog、委托合同编号的修改

### DIFF
--- a/easytrader/clienttrader.py
+++ b/easytrader/clienttrader.py
@@ -475,7 +475,8 @@ class ClientTrader(IClientTrader):
         ).double_click(coords=(x, y))
 
     def refresh(self):
-        self._switch_left_menus(["买入[F1]"], sleep=0.05)
+        #  self._switch_left_menus(["买入[F1]"], sleep=0.05)
+        self._switch_left_menus_by_shortcut("{F5}",sleep=0.1)
 
     @perf_clock
     def _handle_pop_dialogs(self, handler_class=pop_dialog_handler.PopDialogHandler):

--- a/easytrader/pop_dialog_handler.py
+++ b/easytrader/pop_dialog_handler.py
@@ -24,7 +24,7 @@ class PopDialogHandler:
 
     @perf_clock
     def handle(self, title):
-        if any(s in title for s in {"提示信息", "委托确认", "网上交易用户协议"}):
+        if any(s in title for s in {"提示信息", "委托确认", "网上交易用户协议", "撤单确认"}):
             self._submit_by_shortcut()
             return None
 
@@ -41,7 +41,10 @@ class PopDialogHandler:
         return self._app.top_window().Static.window_text()
 
     def _extract_entrust_id(self, content):
-        return re.search(r"\d+", content).group()
+        #  return re.search(r"\d+", content).group()
+        rule = '编号：(.*?)。'
+        ids=re.findall(rule,content)
+        return ids[0]
 
     def _submit_by_click(self):
         try:


### PR DESCRIPTION
1、同花顺的刷新可以用F5作为快捷键，比现在切换F1买入界面刷新好一点。
2、新版本的同花顺的撤单的PopDialog标题是“撤单确认”，需要在PopDialogHandler的handle中加入“撤单确认”，否则不能识别撤单确认菜单，加了这个应该与其他同花顺版本不冲突。
3、下单后委托合同编号提取用正则表达式提取数字不适用于平安证券，平安的合同编号是字母数字组合，所以提取“编号：”和句号之间的作为委托合同编号。