### PR TITLE
增加了华泰证券客户端的国债正回购/逆回购的接口。

### DIFF
--- a/easytrader/clienttrader.py
+++ b/easytrader/clienttrader.py
@@ -177,6 +177,19 @@ class ClientTrader(IClientTrader):
         return {"message": "委托单状态错误不能撤单, 该委托单可能已经成交或者已撤"}
 
     @perf_clock
+    def repo(self, security, price, amount, **kwargs):
+        self._switch_left_menus(["债券回购", "融资回购（正回购）"])
+
+        return self.trade(security, price, amount)
+
+    @perf_clock
+    def reverse_repo(self, security, price, amount, **kwargs):
+        self._switch_left_menus(["债券回购", "融劵回购（逆回购）"])
+
+        return self.trade(security, price, amount)
+
+
+    @perf_clock
     def buy(self, security, price, amount, **kwargs):
         self._switch_left_menus(["买入[F1]"])
 

--- a/easytrader/pop_dialog_handler.py
+++ b/easytrader/pop_dialog_handler.py
@@ -80,6 +80,10 @@ class TradePopDialogHandler(PopDialogHandler):
                 self._submit_by_shortcut()
                 return None
 
+            if "正回购" in content:
+                self._submit_by_shortcut()
+                return None
+
             return None
 
         if title == "提示":

--- a/tests/test_easytrader.py
+++ b/tests/test_easytrader.py
@@ -111,6 +111,18 @@ class TestHTClientTrader(unittest.TestCase):
     def test_auto_ipo(self):
         self._user.auto_ipo()
 
+    def test_invalid_repo(self):
+        import easytrader
+
+        with self.assertRaises(easytrader.exceptions.TradeError):
+            result = self._user.repo("204001", 100, 1)
+
+    def test_invalid_reverse_repo(self):
+        import easytrader
+
+        with self.assertRaises(easytrader.exceptions.TradeError):
+            result = self._user.reverse_repo("204001", 1, 100)
+
 
 @unittest.skipUnless("htzq" in TEST_CLIENTS and IS_WIN_PLATFORM, "skip htzq test")
 class TestHTZQClientTrader(unittest.TestCase):


### PR DESCRIPTION
主要是在原有代码基础上直接把最新的华泰证券客户端对于国债逆回购接口暴露出来。

这个完全是借用了之前已有的代码。可以有接口直接调用。