### PR TITLE
修复同花顺“刷新”；去除对win32gui的引用

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,12 +6,6 @@ import easytrader
 
 ## 二、设置交易客户端类型
 
-**海通客户端**
-
-```python
-user = easytrader.use('htzq_client')
-```
-
 **华泰客户端**
 
 ```python

--- a/easytrader/clienttrader.py
+++ b/easytrader/clienttrader.py
@@ -85,6 +85,7 @@ class ClientTrader(IClientTrader):
         self._config = client.create(self.broker_type)
         self._app = None
         self._main = None
+        self._toolbar = None
 
     def _set_foreground(self, grid=None):
         if grid is None:
@@ -121,6 +122,7 @@ class ClientTrader(IClientTrader):
         self._app = pywinauto.Application().connect(path=connect_path, timeout=10)
         self._close_prompt_windows()
         self._main = self._app.top_window()
+        self._toolbar = self._main.child_window(class_name="ToolbarWindow32")
 
     @property
     def broker_type(self):
@@ -241,6 +243,7 @@ class ClientTrader(IClientTrader):
         :param ttype: 市价委托类型，默认客户端默认选择，
                      深市可选 ['对手方最优价格', '本方最优价格', '即时成交剩余撤销', '最优五档即时成交剩余 '全额成交或撤销']
                      沪市可选 ['最优五档成交剩余撤销', '最优五档成交剩余转限价']
+        :param limit_price:
 
         :return: {'entrust_no': '委托单号'}
         """
@@ -287,9 +290,7 @@ class ClientTrader(IClientTrader):
 
         if len(stock_list) == 0:
             return {"message": "今日无新股"}
-        invalid_list_idx = [
-            i for i, v in enumerate(stock_list) if v[self.config.AUTO_IPO_NUMBER] <= 0
-        ]
+        invalid_list_idx = [i for i, v in enumerate(stock_list) if v[self.config.AUTO_IPO_NUMBER] <= 0]
 
         if len(stock_list) == len(invalid_list_idx):
             return {"message": "没有发现可以申购的新股"}
@@ -309,8 +310,8 @@ class ClientTrader(IClientTrader):
     def _click_grid_by_row(self, row):
         x = self._config.COMMON_GRID_LEFT_MARGIN
         y = (
-            self._config.COMMON_GRID_FIRST_ROW_HEIGHT
-            + self._config.COMMON_GRID_ROW_HEIGHT * row
+                self._config.COMMON_GRID_FIRST_ROW_HEIGHT
+                + self._config.COMMON_GRID_ROW_HEIGHT * row
         )
         self._app.top_window().child_window(
             control_id=self._config.COMMON_GRID_CONTROL_ID,
@@ -322,12 +323,12 @@ class ClientTrader(IClientTrader):
         self.wait(0.5)  # wait dialog display
         try:
             return (
-                self._main.wrapper_object() != self._app.top_window().wrapper_object()
+                    self._main.wrapper_object() != self._app.top_window().wrapper_object()
             )
         except (
-            findwindows.ElementNotFoundError,
-            timings.TimeoutError,
-            RuntimeError,
+                findwindows.ElementNotFoundError,
+                timings.TimeoutError,
+                RuntimeError,
         ) as ex:
             logger.exception("check pop dialog timeout")
             return False
@@ -387,8 +388,8 @@ class ClientTrader(IClientTrader):
     def _get_pop_dialog_title(self):
         return (
             self._app.top_window()
-            .child_window(control_id=self._config.POP_DIALOD_TITLE_CONTROL_ID)
-            .window_text()
+                .child_window(control_id=self._config.POP_DIALOD_TITLE_CONTROL_ID)
+                .window_text()
         )
 
     def _set_trade_params(self, security, price, amount):
@@ -480,8 +481,8 @@ class ClientTrader(IClientTrader):
     def _cancel_entrust_by_double_click(self, row):
         x = self._config.CANCEL_ENTRUST_GRID_LEFT_MARGIN
         y = (
-            self._config.CANCEL_ENTRUST_GRID_FIRST_ROW_HEIGHT
-            + self._config.CANCEL_ENTRUST_GRID_ROW_HEIGHT * row
+                self._config.CANCEL_ENTRUST_GRID_FIRST_ROW_HEIGHT
+                + self._config.CANCEL_ENTRUST_GRID_ROW_HEIGHT * row
         )
         self._app.top_window().child_window(
             control_id=self._config.COMMON_GRID_CONTROL_ID,
@@ -489,7 +490,8 @@ class ClientTrader(IClientTrader):
         ).double_click(coords=(x, y))
 
     def refresh(self):
-        self._switch_left_menus_by_shortcut("{F5}", sleep=0.1)
+        # self._switch_left_menus(["买入[F1]"], sleep=0.05)
+        self._toolbar.button(3).click()		# 我的交易客户端工具栏中“刷新”是排在第4个的，所以其索引值是3
 
     @perf_clock
     def _handle_pop_dialogs(self, handler_class=pop_dialog_handler.PopDialogHandler):
@@ -514,13 +516,13 @@ class BaseLoginClientTrader(ClientTrader):
         pass
 
     def prepare(
-        self,
-        config_path=None,
-        user=None,
-        password=None,
-        exe_path=None,
-        comm_password=None,
-        **kwargs
+            self,
+            config_path=None,
+            user=None,
+            password=None,
+            exe_path=None,
+            comm_password=None,
+            **kwargs
     ):
         """
         登陆客户端

--- a/easytrader/clienttrader.py
+++ b/easytrader/clienttrader.py
@@ -17,7 +17,6 @@ from easytrader.grid_strategies import IGridStrategy
 from easytrader.log import logger
 from easytrader.utils.misc import file2dict
 from easytrader.utils.perf import perf_clock
-from win32gui import SetForegroundWindow, ShowWindow
 
 if not sys.platform.startswith("darwin"):
     import pywinauto
@@ -86,14 +85,6 @@ class ClientTrader(IClientTrader):
         self._app = None
         self._main = None
         self._toolbar = None
-
-    def _set_foreground(self, grid=None):
-        if grid is None:
-            grid = self._trader.main
-        if grid.has_style(pywinauto.win32defines.WS_MINIMIZE):  # if minimized
-            ShowWindow(grid.wrapper_object(), 9)  # restore window state
-        else:
-            SetForegroundWindow(grid.wrapper_object())  # bring to front
 
     @property
     def app(self):
@@ -243,7 +234,6 @@ class ClientTrader(IClientTrader):
         :param ttype: 市价委托类型，默认客户端默认选择，
                      深市可选 ['对手方最优价格', '本方最优价格', '即时成交剩余撤销', '最优五档即时成交剩余 '全额成交或撤销']
                      沪市可选 ['最优五档成交剩余撤销', '最优五档成交剩余转限价']
-        :param limit_price:
 
         :return: {'entrust_no': '委托单号'}
         """
@@ -290,7 +280,9 @@ class ClientTrader(IClientTrader):
 
         if len(stock_list) == 0:
             return {"message": "今日无新股"}
-        invalid_list_idx = [i for i, v in enumerate(stock_list) if v[self.config.AUTO_IPO_NUMBER] <= 0]
+        invalid_list_idx = [
+            i for i, v in enumerate(stock_list) if v[self.config.AUTO_IPO_NUMBER] <= 0
+        ]
 
         if len(stock_list) == len(invalid_list_idx):
             return {"message": "没有发现可以申购的新股"}
@@ -310,8 +302,8 @@ class ClientTrader(IClientTrader):
     def _click_grid_by_row(self, row):
         x = self._config.COMMON_GRID_LEFT_MARGIN
         y = (
-                self._config.COMMON_GRID_FIRST_ROW_HEIGHT
-                + self._config.COMMON_GRID_ROW_HEIGHT * row
+            self._config.COMMON_GRID_FIRST_ROW_HEIGHT
+            + self._config.COMMON_GRID_ROW_HEIGHT * row
         )
         self._app.top_window().child_window(
             control_id=self._config.COMMON_GRID_CONTROL_ID,
@@ -323,12 +315,12 @@ class ClientTrader(IClientTrader):
         self.wait(0.5)  # wait dialog display
         try:
             return (
-                    self._main.wrapper_object() != self._app.top_window().wrapper_object()
+                self._main.wrapper_object() != self._app.top_window().wrapper_object()
             )
         except (
-                findwindows.ElementNotFoundError,
-                timings.TimeoutError,
-                RuntimeError,
+            findwindows.ElementNotFoundError,
+            timings.TimeoutError,
+            RuntimeError,
         ) as ex:
             logger.exception("check pop dialog timeout")
             return False
@@ -388,8 +380,8 @@ class ClientTrader(IClientTrader):
     def _get_pop_dialog_title(self):
         return (
             self._app.top_window()
-                .child_window(control_id=self._config.POP_DIALOD_TITLE_CONTROL_ID)
-                .window_text()
+            .child_window(control_id=self._config.POP_DIALOD_TITLE_CONTROL_ID)
+            .window_text()
         )
 
     def _set_trade_params(self, security, price, amount):
@@ -431,10 +423,6 @@ class ClientTrader(IClientTrader):
         self._main.child_window(control_id=control_id, class_name="Edit").set_edit_text(
             text
         )
-
-    def _type_common_control_keys(self, control, text):
-        self._set_foreground(control)
-        control.type_keys(text, set_foreground=False)
 
     def _type_edit_control_keys(self, control_id, text):
         if not self._editor_need_type_keys:
@@ -481,8 +469,8 @@ class ClientTrader(IClientTrader):
     def _cancel_entrust_by_double_click(self, row):
         x = self._config.CANCEL_ENTRUST_GRID_LEFT_MARGIN
         y = (
-                self._config.CANCEL_ENTRUST_GRID_FIRST_ROW_HEIGHT
-                + self._config.CANCEL_ENTRUST_GRID_ROW_HEIGHT * row
+            self._config.CANCEL_ENTRUST_GRID_FIRST_ROW_HEIGHT
+            + self._config.CANCEL_ENTRUST_GRID_ROW_HEIGHT * row
         )
         self._app.top_window().child_window(
             control_id=self._config.COMMON_GRID_CONTROL_ID,
@@ -490,8 +478,8 @@ class ClientTrader(IClientTrader):
         ).double_click(coords=(x, y))
 
     def refresh(self):
-        # self._switch_left_menus(["买入[F1]"], sleep=0.05)
-        self._toolbar.button(3).click()		# 我的交易客户端工具栏中“刷新”是排在第4个的，所以其索引值是3
+        # self._switch_left_menus_by_shortcut("{F5}", sleep=0.1)
+        self._toolbar.button(3).click()  # 我的交易客户端工具栏中“刷新”是排在第4个的，所以其索引值是3
 
     @perf_clock
     def _handle_pop_dialogs(self, handler_class=pop_dialog_handler.PopDialogHandler):
@@ -516,13 +504,13 @@ class BaseLoginClientTrader(ClientTrader):
         pass
 
     def prepare(
-            self,
-            config_path=None,
-            user=None,
-            password=None,
-            exe_path=None,
-            comm_password=None,
-            **kwargs
+        self,
+        config_path=None,
+        user=None,
+        password=None,
+        exe_path=None,
+        comm_password=None,
+        **kwargs
     ):
         """
         登陆客户端

--- a/easytrader/pop_dialog_handler.py
+++ b/easytrader/pop_dialog_handler.py
@@ -3,24 +3,21 @@ import re
 import time
 from typing import Optional
 
-import pywinauto
-
 from easytrader import exceptions
 from easytrader.utils.perf import perf_clock
-from easytrader.utils.win_gui import SetForegroundWindow, ShowWindow
+from easytrader.utils.win_gui import SetForegroundWindow, ShowWindow, win32defines
 
 
 class PopDialogHandler:
     def __init__(self, app):
         self._app = app
 
-    def _set_foreground(self, grid=None):
-        if grid is None:
-            grid = self._trader.main
-        if grid.has_style(pywinauto.win32defines.WS_MINIMIZE):  # if minimized
-            ShowWindow(grid.wrapper_object(), 9)  # restore window state
+    @staticmethod
+    def _set_foreground(window):
+        if window.has_style(win32defines.WS_MINIMIZE):  # if minimized
+            ShowWindow(window.wrapper_object(), 9)  # restore window state
         else:
-            SetForegroundWindow(grid.wrapper_object())  # bring to front
+            SetForegroundWindow(window.wrapper_object())  # bring to front
 
     @perf_clock
     def handle(self, title):
@@ -40,7 +37,8 @@ class PopDialogHandler:
     def _extract_content(self):
         return self._app.top_window().Static.window_text()
 
-    def _extract_entrust_id(self, content):
+    @staticmethod
+    def _extract_entrust_id(content):
         return re.search(r"[\da-zA-Z]+", content).group()
 
     def _submit_by_click(self):

--- a/easytrader/utils/win_gui.py
+++ b/easytrader/utils/win_gui.py
@@ -1,10 +1,13 @@
 # coding:utf-8
-import win32gui
+from pywinauto import win32defines
+from pywinauto.win32functions import SetForegroundWindow, ShowWindow
 
-
-def SetForegroundWindow(hwd):
-    win32gui.SetForegroundWindow(hwd._as_parameter_)
-
-
-def ShowWindow(hwd, window_status):
-    win32gui.ShowWindow(hwd._as_parameter_, window_status)
+# import win32gui
+#
+#
+# def SetForegroundWindow(hwd):
+#     win32gui.SetForegroundWindow(hwd._as_parameter_)
+#
+#
+# def ShowWindow(hwd, window_status):
+#     win32gui.ShowWindow(hwd._as_parameter_, window_status)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ requests==2.19.1
 six==1.11.0
 urllib3==1.23; python_version != '3.1.*'
 werkzeug==0.14.1
-win32gui
+


### PR DESCRIPTION
一、修复同花顺“刷新”
改为模拟点击工具栏“刷新”按钮。
二、去除对win32gui的引用
1）将所有对SetForegroundWindow, ShowWindow, win32defines的引用全部集中到easytrader.utils.win_gui
2）win_gui.py中，删除对win32gui的引用，改为对pywinauto的引用。（若引用pywinauto有问题，则可以把注释掉的对win32gui的引用瞬间恢复起来）。