### PR TITLE
from easytrader.utils.misc import str2num

### DIFF
--- a/easytrader/webtrader.py
+++ b/easytrader/webtrader.py
@@ -11,7 +11,7 @@ import requests.exceptions
 
 from easytrader import exceptions
 from easytrader.log import logger
-from easytrader.utils.misc import file2dict
+from easytrader.utils.misc import file2dict, str2num
 from easytrader.utils.stock import get_30_date
 
 
@@ -234,13 +234,9 @@ class WebTrader(metaclass=abc.ABCMeta):
             for key in item:
                 try:
                     if re.search(int_match_str, key) is not None:
-                        item[key] = easytrader.utils.misc.str2num(
-                            item[key], "int"
-                        )
+                        item[key] = str2num(item[key], "int")
                     elif re.search(float_match_str, key) is not None:
-                        item[key] = easytrader.utils.misc.str2num(
-                            item[key], "float"
-                        )
+                        item[key] = str2num(item[key], "float")
                 except ValueError:
                     continue
         return response_data


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/shidenggui/easytrader on Python 3.8.3

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./easytrader/webtrader.py:237:37: F821 undefined name 'easytrader'
                        item[key] = easytrader.utils.misc.str2num(
                                    ^
./easytrader/webtrader.py:241:37: F821 undefined name 'easytrader'
                        item[key] = easytrader.utils.misc.str2num(
                                    ^
2     F821 undefined name 'easytrader'
2
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.