### PR TITLE
修复自动打新问题

### DIFF
--- a/easytrader/clienttrader.py
+++ b/easytrader/clienttrader.py
@@ -446,7 +446,7 @@ class ClientTrader(IClientTrader):
 
     @perf_clock
     def _switch_left_menus(self, path, sleep=0.2):
-        self._get_left_menus_handle().get_item(path).click()
+        self._get_left_menus_handle().get_item(path).select()
         self._app.top_window().type_keys('{ESC}')
         self._app.top_window().type_keys('{F5}')
         self.wait(sleep)


### PR DESCRIPTION
自动打新必须先点击"新股申购"，然后"批量新股申购"

原来的code是找到item批量新股申购然后click，这样有时候不成功
换成select()可以解决这个问题

Signed-off-by: Xiaowei Wang <wangxiaowei_cloud@outlook.com>