### PR TITLE
修复华泰证券登入过程死锁的问题

### DIFF
--- a/easytrader/ht_clienttrader.py
+++ b/easytrader/ht_clienttrader.py
@@ -50,14 +50,12 @@ class HTClientTrader(clienttrader.BaseLoginClientTrader):
 
             self._app.top_window().button0.click()
 
-            # detect login is success or not
-            self._app.top_window().wait_not("exists", 100)
-
             self._app = pywinauto.Application().connect(
                 path=self._run_exe_path(exe_path), timeout=10
             )
-        self._close_prompt_windows()
         self._main = self._app.window(title="网上股票交易系统5.0")
+        self._main.wait ( "exists enabled visible ready" , timeout=100 )
+        self._close_prompt_windows ( )
 
     @property
     def balance(self):


### PR DESCRIPTION
华泰证券在登入的过程中会出现死锁，这个死锁问题在单CPU的平台更容易出现
出现问题的步骤：
1，自动输入用户名和密码
2，调用self._app.top_window().wait_not("exists",
100)，等待登入窗口消失，CPU进入睡眠，CPU调度去干别的事情了
3，华泰证券登入成功，登入窗口消失，主窗口出现
4，CPU调度回来，继续执行self._app.top_window().wait_not("exists",
100)，问题是，现在的top_window()不再是登入窗口，而是主窗口，程序一直死等主窗口消失。死锁了

修复办法：
不是dengd登入窗口消失，而是等待主窗口变成visible

Signed-off-by: Xiaowei Wang <wangxiaowei_cloud@outlook.com>