### PR TITLE
修正华泰通讯密码包含特殊字符时不能被正确输入的问题

### DIFF
--- a/easytrader/ht_clienttrader.py
+++ b/easytrader/ht_clienttrader.py
@@ -46,7 +46,7 @@ class HTClientTrader(clienttrader.BaseLoginClientTrader):
             self._app.top_window().Edit1.type_keys(user)
             self._app.top_window().Edit2.type_keys(password)
 
-            self._app.top_window().Edit3.type_keys(comm_password)
+            self._app.top_window().Edit3.set_edit_text(comm_password)
 
             self._app.top_window().button0.click()
 


### PR DESCRIPTION
pywinauto的type_keys方法会将`~`字符当作Enter键 （[ref](https://github.com/pywinauto/pywinauto/blob/df8b9d3419b230b348ef9517f0e196517ac49b63/pywinauto/keyboard.py#L67)）

当通讯密码中包含`~`字符时，通过type_keys方法不能正确输入密码，因此改用set_edit_text方法