### PR TITLE
修复通用版同花顺自动打新功能

### DIFF
--- a/easytrader/clienttrader.py
+++ b/easytrader/clienttrader.py
@@ -520,7 +520,6 @@ class ClientTrader(IClientTrader):
     def _switch_left_menus(self, path, sleep=0.2):
         self.close_pop_dialog()
         self._get_left_menus_handle().get_item(path).select()
-        self._app.top_window().type_keys('{ESC}')
         self._app.top_window().type_keys('{F5}')
         self.wait(sleep)
 


### PR DESCRIPTION
原来代码中,选中“批量新股申购”菜单后会模拟“ESC”键和“F5”键输入。但在通用版同花顺里，“ESC”键输入会导致“批量新股申购”菜单失选，故删除该语句。
用通用版同花顺登陆国联证券账户测试自动打新成功，另测试海通证券客户端无影响。

Signed-off-by: Jack Huang <hqhuang74@gmail.com>