### PR TITLE
fix(sec): upgrade pillow to 9.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ lxml==4.2.3
 markupsafe==1.0
 numpy==1.15.0; python_version >= '2.7'
 pandas==0.23.3
-pillow==5.2.0
+pillow==9.1.1
 pyperclip==1.6.4
 pyquery==1.4.0; python_version != '3.0.*'
 pytesseract==0.2.4


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in pillow 5.2.0
- [MPS-2022-15032](https://www.oscs1024.com/hd/MPS-2022-15032)


### What did I do？
Upgrade pillow from 5.2.0 to 9.1.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS