### PR TITLE
fix bug: 解决即使设置了enable_type_keys_for_editor也无法输入验证码的问题

### DIFF
--- a/easytrader/grid_strategies.py
+++ b/easytrader/grid_strategies.py
@@ -113,9 +113,11 @@ class Copy(BaseStrategy):
                     captcha_num = "".join(captcha_num.split())
                     logger.info("captcha result-->" + captcha_num)
                     if len(captcha_num) == 4:
-                        self._trader.app.top_window().window(
+                        editor = self._trader.app.top_window().window(
                             control_id=0x964, class_name="Edit"
-                        ).set_text(
+                        )
+                        self._trader.type_edit_control_keys(
+                            editor,
                             captcha_num
                         )  # 模拟输入验证码
 


### PR DESCRIPTION
### 问题：
客户端上复制grid数据时，要求输入验证码，但是当前的版本中无法自动输入验证码，即使设置了enable_type_keys_for_editor()属性，对下单之类的输入框生效，但是对验证码输入框不生效。
### 分析：
下单使用type_edit_control_keys方法来输入，该方法在输入的时候会判断enable_type_keys_for_editor()属性，但是验证码的输入框却没有采用该type_edit_control_keys方法来输入，因此无法输入验证码。
### 解决：
验证码的输入过程同样调用type_edit_control_keys方法，这样enable_type_keys_for_editor()属性就可以生效了，问题完美解决。