### PR TITLE
修复price str错误和下单界面错误

### DIFF
--- a/easytrader/clienttrader.py
+++ b/easytrader/clienttrader.py
@@ -455,12 +455,12 @@ class ClientTrader(IClientTrader):
         self.wait(0.1)
 
         # 设置交易所
-        if security.lower().startswith("sz"):
-            self._set_stock_exchange_type("深圳Ａ股")
-        if security.lower().startswith("sh"):
-            self._set_stock_exchange_type("上海Ａ股")
-
-        self.wait(0.1)
+        # if security.lower().startswith("sz"):
+        #     self._set_stock_exchange_type("深圳Ａ股")
+        # if security.lower().startswith("sh"):
+        #     self._set_stock_exchange_type("上海Ａ股")
+        #
+        # self.wait(0.1)
 
         self._type_edit_control_keys(
             self._config.TRADE_PRICE_CONTROL_ID,

--- a/easytrader/joinquant_follower.py
+++ b/easytrader/joinquant_follower.py
@@ -135,3 +135,6 @@ class JoinQuantFollower(BaseFollower):
             transaction["action"] = (
                 "buy" if transaction["transaction"] == "买" else "sell"
             )
+            transaction["price"] = (
+                transaction["price"] if isinstance(transaction["transaction"] ,float) else float(transaction["price"])
+            )


### PR DESCRIPTION
1.Joinquant 返回的transaction["price"] 现在是string，需要转化为float格式，否则会报错;
2.THS 客户端当前没有选择交易市市场的界面，对应操作删除。
Fixes #514