### PR TITLE
fix: 解决多次复制窗口时验证码不验证的问题

### DIFF
--- a/easytrader/grid_strategies.py
+++ b/easytrader/grid_strategies.py
@@ -115,22 +115,18 @@ class Copy(BaseStrategy):
                     if len(captcha_num) == 4:
                         editor = self._trader.app.top_window().window(
                             control_id=0x964, class_name="Edit"
-                        )
+                        ) # 验证码输入框
+                        editor.set_focus() # 焦点移到验证码输入框 (也可不聚焦防止键盘误触输入，不聚焦type_edit_control_keys也可正常输入)
+                        self._trader.wait(0.1) # 输入前短暂等待
                         self._trader.type_edit_control_keys(
                             editor,
                             captcha_num
                         )  # 模拟输入验证码
 
-                        self._trader.app.top_window().set_focus()
-                        pywinauto.keyboard.SendKeys("{ENTER}")  # 模拟发送enter，点击确定
-                        try:
-                            logger.info(
-                                self._trader.app.top_window()
-                                    .window(control_id=0x966, class_name="Static")
-                                    .window_text()
-                            )
-                        except Exception as ex:  # 窗体消失
-                            logger.exception(ex)
+                        self._trader.wait(0.1) # 输完后短暂等待
+                        self._trader.app.top_window().type_keys("{ENTER}", pause=0.1)  # 模拟发送enter，点击确定
+                        if not editor.exists(timeout=1):  # 窗体消失
+                            logger.info("验证码验证成功-->" + captcha_num)
                             found = True
                             break
                     count -= 1


### PR DESCRIPTION
解决从客户端复制网格数据的两个问题：
1. 不要将 Copy._need_captcha_reg 置为 False, 因为它是类方法, 一旦置为 False, 当有多次复制网格数据时, 第一次不需要验证码被设置为False后，后续再复制时，即使有验证码，也不会再进行验证码识别。
2. 复制网格数据时，ctrl+A和ctrl+C之间没有间隔，失败的概率会非常高，测试达到80%以上，添加pause=0.2使两个操作间隔0.2秒，失败概率大幅下降。
3. 用exists更优雅地检测验证码窗口是否消失。