### PR TITLE
修复follower使用miniqmt时，传递entrust_prop参数，而buy函数严格参数检查问题

### DIFF
--- a/easytrader/miniqmt/miniqmt_trader.py
+++ b/easytrader/miniqmt/miniqmt_trader.py
@@ -447,7 +447,7 @@ class MiniqmtTrader:
         return trades
 
     @perf_clock
-    def buy(self, security: str, price: float, amount: int):
+    def buy(self, security: str, price: float, amount: int, **kwargs):
         """
         限价买入
         qmt 官方文档： https://dict.thinktrader.net/nativeApi/xttrader.html?id=7zqjlm#%E8%82%A1%E7%A5%A8%E5%90%8C%E6%AD%A5%E6%8A%A5%E5%8D%95


### PR DESCRIPTION
"C:\Users\charles\AppData\Local\Programs\Python\Python39\lib\site-packages\easytrader\utils\perf.py", line 19, in wrapper
    return f(*args, **kwargs)
TypeError: buy() got an unexpected keyword argument 'entrust_prop'

easytrader/follower.py:315   在调用miniqmt的buy函数时，因为buy函数严格参数检查，缺少entrust_prop参数的接收，导致buy异常。